### PR TITLE
timeout is actually in seconds

### DIFF
--- a/data-sources/datasource.remote.php
+++ b/data-sources/datasource.remote.php
@@ -319,7 +319,7 @@ class RemoteDatasource extends DataSource implements iDatasource
         $label = Widget::Label(__('Timeout'));
         $label->setAttribute('class', 'column');
 
-        $help = new XMLElement('i', __('in minutes'));
+        $help = new XMLElement('i', __('in seconds'));
         $label->appendChild($help);
 
         $timeout_time = isset($settings[self::getClass()]['timeout'])


### PR DESCRIPTION
This fix a minor UI bug where the user was told that timeout was in minutes.
