### PR TITLE
Custom CSV Styles

### DIFF
--- a/data-sources/datasource.remote.php
+++ b/data-sources/datasource.remote.php
@@ -790,7 +790,7 @@ class RemoteDatasource extends DataSource implements iDatasource
         if (empty($this->_env)) {
             $this->_env['env']['pool'] = array(
                 'root' => URL,
-                'workspace' => WORKSPACE
+                'workspace' => URL . '/workspace'
             );
         }
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -59,4 +59,18 @@ class Extension_Remote_Datasource extends Extension
 
         $context['wrapper']->appendChild($label);
     }
+
+    public function install()
+    {
+        Symphony::Configuration()->set('csv-delimiter', ',', 'remote_datasource');
+        Symphony::Configuration()->set('csv-enclosure', '"', 'remote_datasource');
+        Symphony::Configuration()->set('csv-escape', '\\', 'remote_datasource');
+        Symphony::Configuration()->write();
+    }
+
+    public function uninstall()
+    {
+        Symphony::Configuration()->remove('remote_datasource');
+    }
+    
 }

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -11,6 +11,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.2.0" date="2015-06-24" min="2.4" max="2.6.x">
+			- Make CSV style configurable.
+			- Fix `{$workspace}` path
+		</release>
 		<release version="2.1.3" date="2015-05-13" min="2.4" max="2.6.x">
 			- Fix a bug with late static binding on PHP 5.3.
 		</release>

--- a/lib/class.csv.php
+++ b/lib/class.csv.php
@@ -33,6 +33,14 @@ class CSVFormatter implements Transformer
     {
         $headers = array();
 
+        // Get CSV settings
+        $settings = array(
+            'csv-delimiter' => ',',
+            'csv-enclosure' => '"',
+            'csv-escape' => '\\'
+        );
+        $settings = array_merge($settings, (array) Symphony::Configuration()->get('remote_datasource'));
+
         // DOMDocument
         $doc = new DOMDocument('1.0', 'utf-8');
         $doc->formatOutput = true;
@@ -46,14 +54,14 @@ class CSVFormatter implements Transformer
             }
 
             if ($i == 0) {
-                foreach (str_getcsv($row) as $i => $head) {
+                foreach (str_getcsv($row, $settings['csv-delimiter'], $settings['csv-enclosure'], $settings['csv-escape']) as $i => $head) {
                     if (class_exists('Lang')) {
                         $head = Lang::createHandle($head);
                     }
                     $headers[] = $head;
                 }
             } else {
-                self::addRow($doc, $root, str_getcsv($row), $headers);
+                self::addRow($doc, $root, str_getcsv($row, $settings['csv-delimiter'], $settings['csv-enclosure'], $settings['csv-escape']), $headers);
             }
         }
 


### PR DESCRIPTION
- allows custom CSV styles, e. g. using `;` as delimiter instead of `,` (this is common in Germany)
- fixes the `{$workspace}` path