### PR TITLE
Fix incorrect message when datasource times out

### DIFF
--- a/data-sources/datasource.remote.php
+++ b/data-sources/datasource.remote.php
@@ -864,7 +864,7 @@ class RemoteDatasource extends DataSource implements iDatasource
                             $result->appendChild(
                                 new XMLElement(
                                     'error',
-                                    sprintf('Request timed out. %d second limit reached.', $timeout)
+                                    sprintf('Request timed out. %d second limit reached.', $this->dsParamTIMEOUT)
                                 )
                             );
                         } else {


### PR DESCRIPTION
The variable was incorrect, meaning the message would always resolve to:

```
    <error>Request timed out. 0 second limit reached.</error>
```
