### PR TITLE
Pass the namespace parameter to cacheable instances

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -3,7 +3,7 @@ specified, released under the MIT licence as follows:
 
 ----- begin license block -----
 
-Copyright 2011-2017 Symphony Team
+Copyright 2011-2019 Symphony Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/data-sources/datasource.remote.php
+++ b/data-sources/datasource.remote.php
@@ -982,6 +982,7 @@ class RemoteDatasource extends DataSource implements iDatasource
                     $result->setValue(PHP_EOL . str_repeat("\t", 2) . preg_replace('/([\r\n]+)/', "$1\t", $ret));
                     $result->setAttribute('status', ($isCacheValid === true ? 'fresh' : 'stale'));
                     $result->setAttribute('cache-id', $cache_id);
+                    $result->setAttribute('cache-namespace', $this->dsParamROOTELEMENT);
                     $result->setAttribute('creation', $creation);
                 }
             }

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -11,7 +11,10 @@
     </author>
   </authors>
   <releases>
-    <release version="2.3.1" date="2019-01-16" min="2.4" max="3.x.x">
+    <release version="2.4.0" date="2019-02-27" min="2.6" max="3.x.x">
+      - Pass namespace to the cacheable instance
+    </release>
+    <release version="2.3.1" date="2019-02-27" min="2.4" max="3.x.x">
       - [#37](https://github.com/symphonycms/remote_datasource/issues/37) Fix error when multiple datasources are added to the same page with different formats.
     </release>
     <release version="2.3.0" date="2017-07-12" min="2.4" max="3.x.x">


### PR DESCRIPTION
The default Symphony `Cacheable` class has namespaced support but the Remote Datasource extension doesn't use it. This PR updates Remote Datasource to pass through a namespace value. This enables (among other things), simple clearing of datasources by flushing everything by a `$namespace` value rather than reconstructing individual cache ID's:

![screen shot 2019-01-16 at 11 30 14 pm](https://user-images.githubusercontent.com/69268/51295658-b0bf2480-19e6-11e9-9dda-6421df084c41.png)