### PR TITLE
Handle multiple transformers on the same request

### DIFF
--- a/data-sources/datasource.remote.php
+++ b/data-sources/datasource.remote.php
@@ -6,7 +6,7 @@ require_once FACE . '/interface.datasource.php';
 class RemoteDatasource extends DataSource implements iDatasource
 {
 
-    private static $transformer = null;
+    private static $transformer = array();
     private static $url_result = null;
     private static $cacheable = null;
 
@@ -1089,14 +1089,14 @@ class RemoteDatasource extends DataSource implements iDatasource
     {
         $transformer = EXTENSIONS . '/remote_datasource/lib/class.' . strtolower($format) . '.php';
 
-        if (!isset(self::$transformer)) {
+        if (!isset(self::$transformer[$format])) {
             if (file_exists($transformer)) {
                 $classname = require_once $transformer;
-                self::$transformer = new $classname;
+                self::$transformer[$format] = new $classname;
             }
         }
 
-        return self::$transformer;
+        return self::$transformer[$format];
     }
 }
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,62 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension id="remote_datasource" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
-	<name>Remote Datasource</name>
-	<description>A datasource that consumes XML, JSON, CSV or TEXT content.</description>
-	<repo type="github">https://github.com/symphonycms/remote_datasource</repo>
-	<url type="issues">https://github.com/symphonycms/remote_datasource/issues</url>
-	<url type="discuss">https://www.getsymphony.com/discuss/thread/110527/</url>
-	<authors>
-		<author>
-			<name github="symphonycms" symphony="team">Symphony Team</name>
-		</author>
-	</authors>
-	<releases>
-		<release version="2.3.0" date="2017-07-12" min="2.4" max="3.x.x">
-			- Bug fixes
-			- Added compatibility with Symphony 2.7.x and 3.x.x
-		</release>
-		<release version="2.2.1" date="2015-12-01" min="2.4" max="2.6.x">
-			- Fix for php 5.3 compat
-		</release>
-		<release version="2.2.0" date="2015-06-24" min="2.4" max="2.6.x">
-			- Make CSV style configurable.
-			- Fix `{$workspace}` path
-		</release>
-		<release version="2.1.3" date="2015-05-13" min="2.4" max="2.6.x">
-			- Fix a bug with late static binding on PHP 5.3.
-		</release>
-		<release version="2.1.2" date="2014-12-17" min="2.4" max="2.6.x">
-			- Fix the first cache of a result always resulting in an error
-			- Abstract the transformers for better extensibility
-		</release>
-		<release version="2.1.1" date="2014-09-28" min="2.4">
-			- Expose the CURL error via `httpError()`
-			- Fix error with CSV importing
-		</release>
-		<release version="2.1.0" date="2014-06-25" min="2.4">
-			- Add support for text format (a copy of the html response body)
-			- Add some documentation
-		</release>
-		<release version="2.0.1" date="2014-06-24" min="2.4">
-			- Clean-up
-		</release>
-		<release version="2.0.0" date="2014-05-06" min="2.4">
-			- Add support for Symphony 2.4
-			- Support CSV data format
-			- Allow `$gateway` to be manipulated and `$data` to previewed
-			- When the Datasource fails, data is added to the `?debug` page to assist in debugging
-			- Allow no cache to be set
-			- Sanitize XPath to allow for more complex queries
-		</release>
-		<release version="1.1.0" date="2013-02-19" min="2.3" max="2.4">
-			- Officially release the extension
-			- Add `url` to the resulting XML result so you can see what URL was actually fetched
-			- Fix bug where a result would always be `stale`
-			- Allow timeout to be user configurable in the Data Source Editor
-			- Various PHP E_NOTICE fixes
-		</release>
-		<release version="1.0.0" date="2012-03-11" min="2.3">
-			- Initial release
-		</release>
-	</releases>
+  <name>Remote Datasource</name>
+  <description>A datasource that consumes XML, JSON, CSV or TEXT content.</description>
+  <repo type="github">https://github.com/symphonycms/remote_datasource</repo>
+  <url type="issues">https://github.com/symphonycms/remote_datasource/issues</url>
+  <url type="discuss">https://www.getsymphony.com/discuss/thread/110527/</url>
+  <authors>
+    <author>
+      <name github="symphonycms" symphony="team">Symphony Team</name>
+    </author>
+  </authors>
+  <releases>
+    <release version="2.3.1" date="2019-01-16" min="2.4" max="3.x.x">
+      - [#37](https://github.com/symphonycms/remote_datasource/issues/37) Fix error when multiple datasources are added to the same page with different formats.
+    </release>
+    <release version="2.3.0" date="2017-07-12" min="2.4" max="3.x.x">
+      - Bug fixes
+      - Added compatibility with Symphony 2.7.x and 3.x.x
+    </release>
+    <release version="2.2.1" date="2015-12-01" min="2.4" max="2.6.x">
+      - Fix for php 5.3 compat
+    </release>
+    <release version="2.2.0" date="2015-06-24" min="2.4" max="2.6.x">
+      - Make CSV style configurable.
+      - Fix `{$workspace}` path
+    </release>
+    <release version="2.1.3" date="2015-05-13" min="2.4" max="2.6.x">
+      - Fix a bug with late static binding on PHP 5.3.
+    </release>
+    <release version="2.1.2" date="2014-12-17" min="2.4" max="2.6.x">
+      - Fix the first cache of a result always resulting in an error
+      - Abstract the transformers for better extensibility
+    </release>
+    <release version="2.1.1" date="2014-09-28" min="2.4">
+      - Expose the CURL error via `httpError()`
+      - Fix error with CSV importing
+    </release>
+    <release version="2.1.0" date="2014-06-25" min="2.4">
+      - Add support for text format (a copy of the html response body)
+      - Add some documentation
+    </release>
+    <release version="2.0.1" date="2014-06-24" min="2.4">
+      - Clean-up
+    </release>
+    <release version="2.0.0" date="2014-05-06" min="2.4">
+      - Add support for Symphony 2.4
+      - Support CSV data format
+      - Allow `$gateway` to be manipulated and `$data` to previewed
+      - When the Datasource fails, data is added to the `?debug` page to assist in debugging
+      - Allow no cache to be set
+      - Sanitize XPath to allow for more complex queries
+    </release>
+    <release version="1.1.0" date="2013-02-19" min="2.3" max="2.4">
+      - Officially release the extension
+      - Add `url` to the resulting XML result so you can see what URL was actually fetched
+      - Fix bug where a result would always be `stale`
+      - Allow timeout to be user configurable in the Data Source Editor
+      - Various PHP E_NOTICE fixes
+    </release>
+    <release version="1.0.0" date="2012-03-11" min="2.3">
+      - Initial release
+    </release>
+  </releases>
 </extension>


### PR DESCRIPTION
Closes #37

This handles a bug raised by @kmeinke some time ago.

I don't believe the fix is as difficult as thought:

- `$transformer` is a private variable. If someone's using it, it's on them 🙅‍♂️ 
- This value is not persisted to disk for each datasource, so there's no migration required and simply updating the extension will enable them to get the benefit.